### PR TITLE
Allow mouse down and touch start at any position on the track

### DIFF
--- a/src/__tests__/slider.js
+++ b/src/__tests__/slider.js
@@ -7,7 +7,8 @@ test('x', () => {
   expect(component.toJSON()).toMatchInlineSnapshot(`
     <div
       className="css-mcm35l"
-      onClick={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
         className="css-c5m0sj"
@@ -43,7 +44,8 @@ test('y', () => {
   expect(component.toJSON()).toMatchInlineSnapshot(`
     <div
       className="css-1munbi2"
-      onClick={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
         className="css-ee7l6q"
@@ -79,7 +81,8 @@ test('xy', () => {
   expect(component.toJSON()).toMatchInlineSnapshot(`
     <div
       className="css-1rhaxo2"
-      onClick={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
         className="css-0"

--- a/src/slider.js
+++ b/src/slider.js
@@ -77,6 +77,8 @@ const Slider = ({
     if (disabled) return;
 
     e.preventDefault();
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation();
     const dom = handle.current;
     const clientPos = getClientPosition(e);
 

--- a/src/slider.js
+++ b/src/slider.js
@@ -18,7 +18,6 @@ const Slider = ({
   onChange,
   onDragStart,
   onDragEnd,
-  onClick,
   xreverse,
   yreverse,
   styles: customStyles,

--- a/src/slider.js
+++ b/src/slider.js
@@ -134,18 +134,37 @@ const Slider = ({
     }
   }
 
-  function handleClick(e) {
+  function handleTrackMouseDown(e) {
     if (disabled) return;
 
+    e.preventDefault();
     const clientPos = getClientPosition(e);
     const rect = container.current.getBoundingClientRect();
+
+    start.current = {
+      x: clientPos.x - rect.left,
+      y: clientPos.y - rect.top
+    };
+
+    offset.current = {
+      x: clientPos.x,
+      y: clientPos.y
+    };
+
+    document.addEventListener('mousemove', handleDrag);
+    document.addEventListener('mouseup', handleDragEnd);
+    document.addEventListener('touchmove', handleDrag, { passive: false });
+    document.addEventListener('touchend', handleDragEnd);
+    document.addEventListener('touchcancel', handleDragEnd);
 
     change({
       left: clientPos.x - rect.left,
       top: clientPos.y - rect.top
     });
 
-    if (onClick) onClick(e);
+    if (onDragStart) {
+      onDragStart(e);
+    }
   }
 
   const pos = getPosition();
@@ -180,7 +199,8 @@ const Slider = ({
       {...props}
       ref={container}
       css={[styles.track, disabled && styles.disabled]}
-      onClick={handleClick}
+      onTouchStart={handleTrackMouseDown}
+      onMouseDown={handleTrackMouseDown}
     >
       <div css={styles.active} style={valueStyle} />
       <div


### PR DESCRIPTION
Currently, the end-user first needs to locate a thumb (hover a pointer on it or click somewhere on a track) and then start dragging and scrubbing.

https://gyazo.com/de834e1d5a6ed5d7274255dd66e3bfa5

This PR allows the end-user to start dragging at an arbitrary location within the slider, regardless of the thumb position.

https://gyazo.com/00c080f201988bbd58fab6c4f06306ca

As a side effect of this PR, the `onClick` prop, which was useful to detect a click on a track, becomes useless and thus is removed accordingly.